### PR TITLE
fix geoserver link and fix setting to just setup on docker compose

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -54,7 +54,10 @@ uwsgi-base:
     - DJANGO_SETTINGS_MODULE=core.settings.prod_docker
     - VIRTUAL_HOST=haitidata.com
     - VIRTUAL_PORT=8080
-    - SITEURL=http://localhost:33303/
+
+    # Ensure to change these based on server domain
+    - SITEURL=http://0.0.0.0:33300/  # change this to ip or domain location
+    - GEOSERVER_BASE_URL=http://0.0.0.0:33308/geoserver/ # change this to ip or domain geoserver
     # Set your locale - you need to ensure this is created in Dockerfile too...
     - LC_ALL=en_US.UTF-8
   volumes:
@@ -143,7 +146,6 @@ devweb:
     - RABBITMQ_HOST=rabbitmq
     - DJANGO_SETTINGS_MODULE=core.settings.dev_docker
     - PYTHONPATH=/home/web/django_project
-    - SITEURL=http://localhost:33303/
     - VIRTUAL_HOST=haitidata.com
     - VIRTUAL_PORT=8080
   volumes:

--- a/django_project/core/context_processors/project_setting.py
+++ b/django_project/core/context_processors/project_setting.py
@@ -1,0 +1,5 @@
+from django.conf import settings  # import the settings file
+
+
+def project_setting(request):
+    return {'GEOSERVER_BASE_URL': settings.GEOSERVER_BASE_URL}

--- a/django_project/core/settings/base.py
+++ b/django_project/core/settings/base.py
@@ -107,21 +107,11 @@ TEMPLATES = [
                 'account.context_processors.account',
                 'geonode.context_processors.resource_urls',
                 "geonode.geoserver.context_processors.geoserver_urls",
+                "core.context_processors.project_setting.project_setting",
             ],
         },
     },
 ]
-
-MIDDLEWARE_CLASSES = (
-    "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.locale.LocaleMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    'django.contrib.redirects.middleware.RedirectFallbackMiddleware',
-    "pagination.middleware.PaginationMiddleware",
-)
 
 ROOT_URLCONF = 'core.urls'
 

--- a/django_project/core/settings/project.py
+++ b/django_project/core/settings/project.py
@@ -4,13 +4,17 @@ from .base import *
 from django.utils.translation import ugettext_lazy as _
 
 PROJECTION_DIRECTORY = '/tmp/'
-
-GEOSERVER_BASE_URL = 'http://0.0.0.0:33300/geoserver/'
-GEOSERVER_LOCATION = 'http://geoserver:8080/geoserver/'
+GEOSERVER_LOCATION = 'http://geoserver:8080/geoserver/'  # no need to change this
 GEOSERVER_PUBLIC_LOCATION = os.environ.get(
     'GEOSERVER_PUBLIC_LOCATION',
-    'http://0.0.0.0:33308/api/geoserver/'
+    os.environ.get('SITEURL') + 'api/geoserver/'
 )
+
+# dynamic setting based on domain
+GEOSERVER_BASE_URL = os.environ.get(
+    'GEOSERVER_BASE_URL',
+    'http://0.0.0.0:8080/geoserver/'
+)  # change this to geoserver container location
 
 OGC_SERVER = {
     'default': {


### PR DESCRIPTION
## Changes:
- fix geoserver link in dropdown to go to geoserver
- put SITEURL and GEOSERVER_BASE_URL in docker compose environtment to make it easier to changed

## How to implement it:
- change SITEURL -> domain + port 33300 
- change GEOSERVER_BASE_URL -> domain + port 33308
- make deploy

to change to use 80, we could change in here 
https://github.com/HaitiData/haitidata/blob/development/deployment/docker-compose.yml#L126
to `- "80:8080"`
or maybe use nginx redirect url to redirect 33300 to new url