### PR TITLE
revert react to use wms because of breaking legend

### DIFF
--- a/django_project/core/templates/geonode-client/layer_map.html
+++ b/django_project/core/templates/geonode-client/layer_map.html
@@ -43,17 +43,6 @@
     if (config.proxy !== '') {
       options.proxy = "{{PROXY_URL}}";
     }
-    {% if resource.get_tiles_url %}
-        var tiles_url = "{{ resource.get_tiles_url|safe }}";
-        var last_letter_url =  tiles_url.charAt(tiles_url.length - 1);
-        if(parseInt(last_letter_url)) {
-            tiles_url = tiles_url.substring(0, tiles_url.length - 1);
-        }
-        tiles_url  = tiles_url.split('?')[0];
-        tiles_url = tiles_url.replace('gmaps','wms');
-        access_token = options.mapConfig.sources[2].url.split('?')[1];
-        options.mapConfig.sources[2].url = tiles_url+'?'+access_token+'&SRS={{ crs }}';
-    {% endif %}
     var viewer = new window.Viewer('preview_map', options);
     viewer.view();
 });


### PR DESCRIPTION
It was using gwc because i think it is the best to use gwc instead wms. But it seems it breaks getting proxy, specially for legend.