### PR TITLE
[WIP] download wcs instead if no layer found in geonode

### DIFF
--- a/django_project/clip-and-ship/views.py
+++ b/django_project/clip-and-ship/views.py
@@ -19,6 +19,7 @@ def clip_layer(request, layername):
     :type layername: basestring
     :return: file size
     """
+
     # PREPARATION
     layer = None
     raster_filepath = None
@@ -51,17 +52,21 @@ def clip_layer(request, layername):
     except OSError as e:
         pass
 
-    # get file for raster
-    if not raster_filepath:
-        file_names = []
-        for layerfile in layer.upload_session.layerfile_set.all():
-            file_names.append(layerfile.file.path)
+    try:
+        # get file for raster
+        if not raster_filepath:
+            file_names = []
+            for layerfile in layer.upload_session.layerfile_set.all():
+                file_names.append(layerfile.file.path)
 
-        for target_file in file_names:
-            if '.tif' in target_file:
-                raster_filepath = target_file
-                extention = 'tif'
-                break
+            for target_file in file_names:
+                if '.tif' in target_file:
+                    raster_filepath = target_file
+                    extention = 'tif'
+                    break
+    except AttributeError:
+        raise Http404('Project can not be clipped or masked.')
+
 
     # get temp filename for output
     filename = os.path.basename(raster_filepath)

--- a/django_project/clip-and-ship/views.py
+++ b/django_project/clip-and-ship/views.py
@@ -41,6 +41,12 @@ def clip_layer(request, layername):
     params = {
         param.upper(): value for param, value in query.iteritems()}
     bbox_string = params.get('BBOX', '')
+    bboxArray = bbox_string.split(',')
+    southwest_lat = bboxArray[1]
+    bboxArray[1] = bboxArray[3]
+    bboxArray[3] = southwest_lat
+
+    bbox_string = ','.join(bboxArray)
     geojson = params.get('GEOJSON', '')
     current_date = datetime.datetime.today().strftime('%Y-%m-%d_%H-%M-%S')
 
@@ -66,7 +72,6 @@ def clip_layer(request, layername):
                     break
     except AttributeError:
         raise Http404('Project can not be clipped or masked.')
-
 
     # get temp filename for output
     filename = os.path.basename(raster_filepath)

--- a/django_project/core/templates/clip-and-ship/download-clip.html
+++ b/django_project/core/templates/clip-and-ship/download-clip.html
@@ -1,4 +1,5 @@
 {% load staticfiles %}
+<a id="download-wcs" target="_blank">DOWNLOAD</a>
 
 <link rel="stylesheet" href="{% static 'geonode/css/leaflet.draw.css' %}"/>
 <script src="{% static 'geonode/js/draw/leaflet.draw.js' %}"></script>
@@ -99,19 +100,24 @@
         {% endif %}
     });
 
+    function download_clip_wcs(clipUrl, geometry_url) {
+        var layer_name = clipUrl.replace('/clip/', '');
+        var ship_url = '{{ GEOSERVER_BASE_URL }}/wcs?filename={{ resource.name }}.tif&request=getcoverage&version=1.0.0&service=wcs&coverage=' + layer_name + '&CRS=EPSG:4326&format=geotiff&resx=0.5&resy=0.5' + geometry_url
+        window.open(ship_url);
+    }
+
     function download_clip_layer(clipUrl, geometry_url) {
         var ship_url = clipUrl + '/clip-layer?' + geometry_url;
         $.ajax({
             url: ship_url,
             type: 'GET',
             success: function (result) {
-                $('#download-clip-button').prop('disabled', false);
                 var clip_filename = result['clip_filename'];
                 location.href = clipUrl + '/' + clip_filename + '/download-clip';
                 editableLayers.clearLayers();
             },
             error: function (result) {
-                $('#download-clip-button').prop('disabled', false);
+                download_clip_wcs(clipUrl, geometry_url);
                 var error_message = result['responseJSON']['error'];
                 var $errorMessageDisplay = $('#download-clip-error-message');
                 $errorMessageDisplay.html(error_message);
@@ -123,8 +129,6 @@
 
     $('#download-clip-button').click(function () {
         var url = '';
-        $('#download-clip-button').prop('disabled', true);
-
         // Open Popup
         var map_type_name = "{{ resource.service_typename }}";
 

--- a/django_project/core/templates/clip-and-ship/download-clip.html
+++ b/django_project/core/templates/clip-and-ship/download-clip.html
@@ -83,8 +83,6 @@
 
             editableLayers.addLayer(layer);
         });
-
-
     });
 
 
@@ -102,7 +100,7 @@
 
     function download_clip_wcs(clipUrl, geometry_url) {
         var layer_name = clipUrl.replace('/clip/', '');
-        var ship_url = '{{ GEOSERVER_BASE_URL }}/wcs?filename={{ resource.name }}.tif&request=getcoverage&version=1.0.0&service=wcs&coverage=' + layer_name + '&CRS=EPSG:4326&format=geotiff&resx=0.5&resy=0.5' + geometry_url
+        var ship_url = '{{ GEOSERVER_BASE_URL }}/wcs?filename={{ resource.name }}.tif&request=getcoverage&version=1.0.0&service=wcs&coverage=' + layer_name + '&CRS=EPSG:4326&format=geotiff&resx=0.5&resy=0.5' + geometry_url;
         window.open(ship_url);
     }
 
@@ -151,9 +149,6 @@
         if (mapToClip) {
             var bboxString = mapToClip.getBounds().toBBoxString();
             var bboxArray = bboxString.split(',');
-            var southwest_lat = bboxArray[1];
-            bboxArray[1] = bboxArray[3];
-            bboxArray[3] = southwest_lat;
             download_clip_layer(clipUrl, '&BBOX=' + bboxArray.toString());
         }
     });


### PR DESCRIPTION
Download from wcs instead if no physic layer found in geonode.
example of calls
```
http://192.168.1.6:8080/geoserver/wcs?filename=ortho_images.tif&request=getcoverage&version=1.0.0&service=wcs&coverage=geonode:ortho_images&CRS=EPSG:4326&format=geotiff&resx=0.5&resy=0.5&BBOX=-72.21525907516481,19.285160039165955,-72.20307111740114,19.27705839574861
```

but got error:
```
<ServiceExceptionReport version="1.2.0"><ServiceException code="InvalidParameterValue" locator="bbox">
      illegal bbox, minY: 19.290324627643272 is greater than maxY: 19.274121451053258
</ServiceException></ServiceExceptionReport>
```
Not sure why, although on coverage:
```
<wcs:lonLatEnvelope srsName="urn:ogc:def:crs:OGC:1.3:CRS84">
<gml:pos>-72.22382168633042 19.15181281747936</gml:pos>
<gml:pos>-71.65129148470884 19.29671685220578</gml:pos>
</wcs:lonLatEnvelope>
```