### PR TITLE
download wcs instead if no layer found in geonode

### DIFF
--- a/django_project/clip-and-ship/views.py
+++ b/django_project/clip-and-ship/views.py
@@ -43,15 +43,20 @@ def clip_layer(request, layername):
     raster_filepath = None
     extention = ''
 
-    file_names = []
-    for layerfile in layer.upload_session.layerfile_set.all():
-        file_names.append(layerfile.file.path)
+    # get file for raster
+    try:
+        if not raster_filepath:
+            file_names = []
+            for layerfile in layer.upload_session.layerfile_set.all():
+                file_names.append(layerfile.file.path)
 
-    for target_file in file_names:
-        if '.tif' in target_file:
-            raster_filepath = target_file
-            extention = 'tif'
-            break
+            for target_file in file_names:
+                if '.tif' in target_file:
+                    raster_filepath = target_file
+                    extention = 'tif'
+                    break
+    except AttributeError:
+        raise Http404('Project file not found.')
 
     # get temp filename for output
     filename = os.path.basename(raster_filepath)

--- a/django_project/clip-and-ship/views.py
+++ b/django_project/clip-and-ship/views.py
@@ -57,6 +57,11 @@ def clip_layer(request, layername):
                     raster_filepath = target_file
                     extention = 'tif'
                     break
+        bbox_array = bbox_string.split(',')
+        southwest_lat = bbox_array[1]
+        bbox_array[1] = bbox_array[3]
+        bbox_array[3] = southwest_lat
+        bbox_string = ','.join(bbox_array)
     except AttributeError:
         # Call wcs command
         wcs_url = 'http://geoserver:8080/geoserver/wcs?request=getcoverage&' \

--- a/django_project/clip-and-ship/views.py
+++ b/django_project/clip-and-ship/views.py
@@ -64,9 +64,13 @@ def clip_layer(request, layername):
                   'format=geotiff&crs=EPSG:4326&bbox={bbox}&width={width}&' \
                   'height={height}'
 
-        # TODO : Get width & height
-        width = 731
-        height = 484
+        bbox_array = bbox_string.split(',')
+        offset = 50
+        x = float(bbox_array[2]) - float(bbox_array[0])
+        width = int(x * 43260) + offset
+
+        y = float(bbox_array[3]) - float(bbox_array[1])
+        height = int(y * 43260) + offset
 
         wcs_formatted_url = wcs_url.format(
             layer_name=layername,

--- a/django_project/clip-and-ship/views.py
+++ b/django_project/clip-and-ship/views.py
@@ -64,7 +64,7 @@ def clip_layer(request, layername):
         bbox_string = ','.join(bbox_array)
     except AttributeError:
         # Call wcs command
-        wcs_url = 'http://geoserver:8080/geoserver/wcs?request=getcoverage&' \
+        wcs_url = settings.GEOSERVER_LOCATION + 'wcs?request=getcoverage&' \
                   'version=1.0.0&service=WCS&coverage={layer_name}&' \
                   'format=geotiff&crs=EPSG:4326&bbox={bbox}&width={width}&' \
                   'height={height}'

--- a/django_project/core/templates/layers/download_clip.html
+++ b/django_project/core/templates/layers/download_clip.html
@@ -138,6 +138,7 @@
 
     function download_clip_layer(clipUrl, geometry_url) {
         var ship_url = clipUrl + '/clip-layer?' + geometry_url;
+        console.log(ship_url);
         $.ajax({
             url: ship_url,
             type: 'GET',
@@ -145,9 +146,11 @@
                 $('#download-clip-button').prop('disabled', false);
                 var clip_filename = result['clip_filename'];
                 location.href = clipUrl + '/' + clip_filename + '/download-clip';
+                console.log(clipUrl + '/' + clip_filename + '/download-clip');
                 editableLayers.clearLayers();
             },
             error: function (result) {
+                console.log(clipUrl + '/' + clip_filename + '/download-clip');
                 download_clip_wcs(clipUrl, geometry_url);
                 $('#download-clip-button').prop('disabled', false);
                 var error_message = result['responseJSON']['error'];
@@ -171,7 +174,9 @@
         if (editableLayers) {
             var geojson = editableLayers.toGeoJSON();
             if (geojson.features.length > 0) {
+                var bboxEditableLayers = editableLayers.getBounds().toBBoxString();
                 var geometry_url = '&GEOJSON=' + JSON.stringify(geojson);
+                geometry_url += '&BBOX=' + bboxEditableLayers.toString();
                 download_clip_layer(clipUrl, geometry_url);
                 return;
             } else {

--- a/django_project/core/templates/layers/download_clip.html
+++ b/django_project/core/templates/layers/download_clip.html
@@ -129,13 +129,6 @@
         {% endif %}
     });
 
-    function download_clip_wcs(clipUrl, geometry_url) {
-        var layer_name = clipUrl.replace('/clip/', '');
-        var ship_url = '{{ GEOSERVER_BASE_URL }}/wcs?filename={{ resource.name }}.tif&request=getcoverage&version=1.0.0&service=wcs&coverage=' + layer_name + '&CRS=EPSG:4326&format=geotiff&resx=0.5&resy=0.5' + geometry_url;
-        console.log(ship_url);
-        // window.open(ship_url);
-    }
-
     function download_clip_layer(clipUrl, geometry_url) {
         var ship_url = clipUrl + '/clip-layer?' + geometry_url;
         console.log(ship_url);
@@ -151,7 +144,6 @@
             },
             error: function (result) {
                 console.log(clipUrl + '/' + clip_filename + '/download-clip');
-                download_clip_wcs(clipUrl, geometry_url);
                 $('#download-clip-button').prop('disabled', false);
                 var error_message = result['responseJSON']['error'];
                 var $errorMessageDisplay = $('#download-clip-error-message');

--- a/django_project/core/templates/layers/download_clip.html
+++ b/django_project/core/templates/layers/download_clip.html
@@ -94,9 +94,9 @@
                 tiles_url = tiles_url.substring(0, tiles_url.length - 1);
             }
             tile_layer = L.tileLayer(tiles_url,
-                    {
-                        'opacity': 0.8
-                    });
+                {
+                    'opacity': 0.8
+                });
         {% endif %}
 
         if (tile_layer) {
@@ -108,7 +108,7 @@
 
         mapToClip.on(L.Draw.Event.CREATED, function (e) {
             var type = e.layerType,
-                    layer = e.layer;
+                layer = e.layer;
 
             editableLayers.addLayer(layer);
         });
@@ -129,6 +129,12 @@
         {% endif %}
     });
 
+    function download_clip_wcs(clipUrl, geometry_url) {
+        var layer_name = clipUrl.replace('/clip/', '');
+        var ship_url = '{{ GEOSERVER_BASE_URL }}/wcs?filename={{ resource.name }}.tif&request=getcoverage&version=1.0.0&service=wcs&coverage=' + layer_name + '&CRS=EPSG:4326&format=geotiff&resx=0.5&resy=0.5' + geometry_url;
+        window.open(ship_url);
+    }
+
     function download_clip_layer(clipUrl, geometry_url) {
         var ship_url = clipUrl + '/clip-layer?' + geometry_url;
         $.ajax({
@@ -141,6 +147,7 @@
                 editableLayers.clearLayers();
             },
             error: function (result) {
+                download_clip_wcs(clipUrl, geometry_url);
                 $('#download-clip-button').prop('disabled', false);
                 var error_message = result['responseJSON']['error'];
                 var $errorMessageDisplay = $('#download-clip-error-message');
@@ -177,9 +184,6 @@
         if (mapToClip) {
             var bboxString = mapToClip.getBounds().toBBoxString();
             var bboxArray = bboxString.split(',');
-            var southwest_lat = bboxArray[1];
-            bboxArray[1] = bboxArray[3];
-            bboxArray[3] = southwest_lat;
             download_clip_layer(clipUrl, '&BBOX=' + bboxArray.toString());
         }
     });

--- a/django_project/core/templates/layers/download_clip.html
+++ b/django_project/core/templates/layers/download_clip.html
@@ -132,7 +132,8 @@
     function download_clip_wcs(clipUrl, geometry_url) {
         var layer_name = clipUrl.replace('/clip/', '');
         var ship_url = '{{ GEOSERVER_BASE_URL }}/wcs?filename={{ resource.name }}.tif&request=getcoverage&version=1.0.0&service=wcs&coverage=' + layer_name + '&CRS=EPSG:4326&format=geotiff&resx=0.5&resy=0.5' + geometry_url;
-        window.open(ship_url);
+        console.log(ship_url);
+        // window.open(ship_url);
     }
 
     function download_clip_layer(clipUrl, geometry_url) {


### PR DESCRIPTION
this fix #67 
When download from wcs, it said:
```
<ServiceExceptionReport version="1.2.0"><ServiceException>
      java.lang.IllegalArgumentException: Illegal value for argument "resolutions".
Illegal value for argument "resolutions".
</ServiceException></ServiceExceptionReport>
```